### PR TITLE
Update scripts to create db and load alberta data

### DIFF
--- a/src/load_alberta/create_db.py
+++ b/src/load_alberta/create_db.py
@@ -132,41 +132,13 @@ query = f"""
         data_display varchar(150),
         level_develop varchar(40),
         use_type2 varchar(25),
-        picture integer,
         geometry geometry(geometry, {appconfig.dataSrid}) not null,
         primary key(id)
     );
     create index {trailTable}_geom_idx on {appconfig.dataSchema}.{trailTable} using gist(geometry);
     
-    create table {appconfig.dataSchema}.{appconfig.fishSpeciesTable}(
-        code varchar(4),
-        name varchar,
-        allcodes varchar[],
-        
-        accessibility_gradient double precision not null,
-        
-        habitat_gradient_min numeric,
-        habitat_gradient_max numeric,
-        
-        habitat_discharge_min numeric,
-        habitat_discharge_max numeric,
-        
-        habitat_channel_confinement_min numeric,
-        habitat_channel_confinement_max numeric,
-        
-        primary key (code)
-    );
-    insert into {appconfig.dataSchema}.{appconfig.fishSpeciesTable}(
-        code, name, allcodes, accessibility_gradient, 
-        habitat_gradient_min,habitat_gradient_max,habitat_discharge_min,habitat_discharge_max,
-        habitat_channel_confinement_min, habitat_channel_confinement_max)
-    values 
-        ('argr', 'Arctic Grayling', ARRAY['argr'], 0.35, 0, 0.35, 0, 100, 0, 100),
-        ('wbtr', 'Western Arctic Bull Trout', ARRAY['wbtr', 'bltr'], 0.35, 0, 0.35, 0, 100, 0, 100),
-        ('mnwh', 'Mountain Whitefish', ARRAY['mnwh'], 0.35, 0, 0.35, 0, 100, 0, 100),
-        ('artr', 'Athabasca Rainbow Trout', ARRAY['artr', 'rntr'], 0.35, 0, 0.35, 0, 100, 0, 100);
 """
-#print (query)
+
 with appconfig.connectdb() as conn:
     with conn.cursor() as cursor:
         cursor.execute(query)

--- a/src/load_alberta/load_alberta.py
+++ b/src/load_alberta/load_alberta.py
@@ -45,6 +45,8 @@ with appconfig.connectdb() as conn:
     subprocess.run(pycmd)
     
     query = f"""
+    TRUNCATE TABLE {datatable};
+
     INSERT INTO {datatable} (id, waterbody_id, stream_name, feature_type, strahler_order, 
     watershed_id, hydro_code, fish_species, geometry) 
     SELECT uuid_generate_v4(), wb_id, name, feature_type, str_order::integer,
@@ -54,7 +56,7 @@ with appconfig.connectdb() as conn:
     
     DROP table {temptable};
     """
-    #print(query)
+    
     with conn.cursor() as cursor:
         cursor.execute(query)
     conn.commit()
@@ -68,6 +70,8 @@ with appconfig.connectdb() as conn:
     subprocess.run(pycmd)
     
     query = f"""
+    TRUNCATE TABLE {datatable};
+
     INSERT INTO {datatable} (
     id, feature_type, name, highway_number, road_class, geo_source, geo_date, feature_type_source,
     feature_type_date,globalid,update_date,geometry)         
@@ -82,7 +86,7 @@ with appconfig.connectdb() as conn:
     
     DROP table {temptable};
     """
-    #print(query)
+    
     with conn.cursor() as cursor:
         cursor.execute(query)
     conn.commit()
@@ -96,6 +100,8 @@ with appconfig.connectdb() as conn:
     subprocess.run(pycmd)
     
     query = f"""
+    TRUNCATE TABLE {datatable};
+
     INSERT INTO {datatable} (id, feature_type, geo_source, geo_date, 
     feature_type_source, feature_type_date, globalid, update_date, geometry) 
     SELECT uuid_generate_v4(), feature_type, geo_source, geo_date, 
@@ -105,7 +111,7 @@ with appconfig.connectdb() as conn:
     
     DROP table {temptable};
     """
-    #print(query)
+
     with conn.cursor() as cursor:
         cursor.execute(query)        
     conn.commit()
@@ -118,6 +124,8 @@ with appconfig.connectdb() as conn:
     #print(pycmd)
     subprocess.run(pycmd)
     query = f"""
+    TRUNCATE TABLE {datatable};
+
     INSERT INTO {datatable} (
     id,name,trailid,type,status,season,designation,surface,use_type,accessibility,
     commercial_operator,adopted,land_ownership,average_width,minimum_clearing_width,
@@ -138,7 +146,8 @@ with appconfig.connectdb() as conn:
     conditionsource,comments,datasource,dispositionnum,dateupdate,updateby,datasourcedate,
     link,datadisplay,leveldevelop,usetype,st_geometryn(geometry, generate_series(1, st_numgeometries(geometry))) 
     FROM
-    {temptable};
+    {temptable}
+    WHERE st_numgeometries(geometry) <> 0;
     
     --data without geometries
     INSERT INTO {datatable} (
@@ -171,7 +180,6 @@ with appconfig.connectdb() as conn:
 
     """
     
-    #print(query)
     with conn.cursor() as cursor:
         cursor.execute(query)
     conn.commit()

--- a/src/processing_scripts/compute_barriers_upstream_values.py
+++ b/src/processing_scripts/compute_barriers_upstream_values.py
@@ -542,11 +542,11 @@ def writeResults(connection):
     with connection.cursor() as cursor:
         cursor.execute(query)
 
-    # query = f"""
-    #     DROP TABLE {dbTargetSchema}.temp;
-    # """
-    # with connection.cursor() as cursor:
-    #     cursor.execute(query)             
+    query = f"""
+        DROP TABLE {dbTargetSchema}.temp;
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(query)        
 
     connection.commit()
 
@@ -601,8 +601,6 @@ def main():
             
         print("  writing results")
         writeResults(conn)
-        
-        
         
     print("done")
     


### PR DESCRIPTION
- picture field is no longer created in trails table (empty and not relevant for our analyses)
- automatic creation of fish species table removed as it is now created by load_parameters.py
- load_alberta.py now truncates existing tables to prevent data from being duplicated.
- added a WHERE clause when loading trail data to prevent duplication of trails with empty geometries
- temp table is now dropped after computing upstream values for barriers