### PR TITLE
Revise habitat/connectivity status calculations; minor updates to modelled crossings

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,14 @@ load_and_snap_fishobservations.py -c config.ini [watershedid] -user [username] -
 
 ---
 #### 4 - Compute Modelled Crossings
-This script computes modelled crossings defined as locations where rail, road, or trails cross stream networks (based on feature geometries). Due to mapping errors, these crossings may not actually exist on the ground.
+This script computes modelled crossings defined as locations where rail, road, or trails cross stream networks (based on feature geometries). Due to mapping errors, these crossings may not actually exist on the ground.   
+
+The modelled_id field for modelled crossings is a stable id. The second and all subsequent runs of compute_modelled_crossings.py will create an archive table of previous modelled crossings, and assign the modelled_id for newly generated crossings to their previous values, based on a distance threshold of 10 m.
 
 
 **Script**
 
-load_modelled_crossings.py -c config.ini [watershedid] -user [username] -password [password]
+compute_modelled_crossings.py -c config.ini [watershedid] -user [username] -password [password]
 
 **Input Requirements**
 
@@ -442,6 +444,8 @@ Habitat models are based on all of the following calculations for each species r
 * Gradient: stream_gradient ≥ gradient_min AND stream_gradient < gradient_max AND species_accessibility IN (ACCESSIBLE OR POTENTIALLY ACCESSIBLE)
 * Discharge (m3/s): stream_discharge ≥ discharge_min AND stream_discharge < discharge_max AND species_accessibility IN (ACCESSIBLE OR POTENTIALLY ACCESSIBLE)
 * Channel confinement (ratio of valley width / channel width): always true for now - model to be defined later
+
+Habitat models are also based on Strahler order - stream segments with a Strahler order of 1 are not considered suitable habitat for any species.
 
 gradient_min, gradient_max, discharge_min, and discharge_max are parameters defined for each fish species in the hydro.fish_species table. These parameters are separated in the fish_species table by spawning and rearing habitat.
 

--- a/src/compute_watershed_stats.py
+++ b/src/compute_watershed_stats.py
@@ -43,6 +43,7 @@ def main():
             accessible_spawn_all_km numeric,
             accessible_rear_all_km numeric,
             accessible_habitat_all_km numeric,
+            potentially_accessible_habitat_all_km numeric,
             total_spawn_all_km numeric,
             total_rear_all_km numeric,
             total_habitat_all_km numeric,
@@ -97,6 +98,7 @@ def main():
             allfishspawn_query = ''
             allfishrear_query = ''
             allfishhabitat_query = ''
+            allfishpotentialaccesshabitat_query = ''
 
             allfishaccess = None
             allfishpotentialaccess = None
@@ -106,6 +108,7 @@ def main():
             allfishspawn = None
             allfishrear = None
             allfishhabitat = None
+            allfishpotentialaccesshabitat = None
 
             for fish in fishes: 
                 
@@ -181,7 +184,13 @@ def main():
                 else:
                     allfishaccesshabitat = allfishaccesshabitat + " OR "
                 allfishaccesshabitat = allfishaccesshabitat + f"""({fish}_accessibility = '{appconfig.Accessibility.ACCESSIBLE.value}' AND habitat_{fish} = true)"""
-                
+
+                if (allfishpotentialaccesshabitat is None):
+                    allfishpotentialaccesshabitat = ''
+                else:
+                    allfishpotentialaccesshabitat = allfishpotentialaccesshabitat + " OR "
+                allfishpotentialaccesshabitat = allfishpotentialaccesshabitat + f"""({fish}_accessibility = '{appconfig.Accessibility.POTENTIAL.value}' AND habitat_{fish} = true)"""
+
                 fishspawnhabitat_query = f"""
                     {fishspawnhabitat_query}                
                     WITH alldata AS ({alldataquery})
@@ -288,9 +297,16 @@ def main():
                 WHERE watershed_id = '{watershed_id}';
             """
 
+            allfishpotentialaccesshabitat_query = f"""
+                WITH alldata AS ({alldataquery})
+                UPDATE {appconfig.dataSchema}.{statTable} SET potentially_accessible_habitat_all_km =
+                (SELECT sum(segment_length) from alldata WHERE {allfishpotentialaccesshabitat})
+                WHERE watershed_id = '{watershed_id}';
+            """
+
             connectivity_status_query = f"""        
                 UPDATE {appconfig.dataSchema}.{statTable} SET connectivity_status =
-                (SELECT (accessible_all_km / (accessible_all_km + potentially_accessible_all_km))
+                (SELECT (accessible_habitat_all_km / (accessible_habitat_all_km + potentially_accessible_habitat_all_km))
                 FROM {appconfig.dataSchema}.{statTable}
                 WHERE watershed_id = '{watershed_id}')
                 WHERE watershed_id = '{watershed_id}';
@@ -314,6 +330,7 @@ def main():
                 {allfishspawn_query}
                 {allfishrear_query}
                 {allfishhabitat_query}
+                {allfishpotentialaccesshabitat_query}
                 {connectivity_status_query}
             """
             
@@ -326,5 +343,3 @@ def main():
     
 if __name__ == "__main__":
     main()     
-
-

--- a/src/compute_watershed_stats.py
+++ b/src/compute_watershed_stats.py
@@ -47,7 +47,9 @@ def main():
             total_spawn_all_km numeric,
             total_rear_all_km numeric,
             total_habitat_all_km numeric,
-            connectivity_status numeric
+            connectivity_status numeric,
+
+            primary key (watershed_id)
         );
     """
     with appconfig.connectdb() as connection:

--- a/src/processing_scripts/compute_habitat_models.py
+++ b/src/processing_scripts/compute_habitat_models.py
@@ -303,7 +303,8 @@ def computeHabitatModel(connection):
 
                 UPDATE {dbTargetSchema}.{dbTargetStreamTable} 
                     SET {colname} = true
-                    WHERE {gradient} = true AND {discharge} = true AND {chn_confine} = true;
+                    WHERE {gradient} = true AND {discharge} = true AND {chn_confine} = true
+                    AND strahler_order <> 1;
                 
                 ALTER TABLE {dbTargetSchema}.{dbTargetStreamTable}
                     DROP COLUMN {gradient},
@@ -342,7 +343,8 @@ def computeHabitatModel(connection):
 
                 UPDATE {dbTargetSchema}.{dbTargetStreamTable} 
                     SET {colname} = true
-                    WHERE {gradient} = true AND {discharge} = true AND {chn_confine} = true;
+                    WHERE {gradient} = true AND {discharge} = true AND {chn_confine} = true
+                    AND strahler_order <> 1;
                 
                 ALTER TABLE {dbTargetSchema}.{dbTargetStreamTable}
                     DROP COLUMN {gradient},

--- a/src/processing_scripts/compute_modelled_crossings.py
+++ b/src/processing_scripts/compute_modelled_crossings.py
@@ -51,36 +51,14 @@ def createTable(connection):
             stream_name varchar,
             strahler_order integer,
             stream_id uuid, 
-            -- stream_measure numeric,
-            -- wshed_name varchar,
-            -- wshed_priority varchar,
             transport_feature_name varchar,
-            -- ownership_type varchar,
-            
-            -- species_upstr varchar[],
-            -- species_downstr varchar[],
-            -- stock_upstr varchar[],
-            -- stock_downstr varchar[],
-            
-            -- barriers_upstr varchar[],
-            -- barriers_downstr varchar[],
-            -- barrier_cnt_upstr integer,
-            -- barrier_cnt_downstr integer,
-            
-            -- critical_habitat varchar[],
             
             passability_status varchar,
-            -- last_inspection date,
             
             crossing_status varchar,
             crossing_feature_type varchar CHECK (crossing_feature_type IN ('ROAD', 'RAIL', 'TRAIL')),
             crossing_type varchar,
             crossing_subtype varchar,
-            
-            -- habitat_quality varchar,
-            -- year_planned integer,
-            -- year_complete integer,
-            -- comments varchar,
             
             geometry geometry(Point, {appconfig.dataSrid}),
             

--- a/src/processing_scripts/load_and_snap_barriers_cabd.py
+++ b/src/processing_scripts/load_and_snap_barriers_cabd.py
@@ -92,7 +92,6 @@ def main():
                 primary key (id)
             );
             
-            delete from {dbTargetSchema}.{dbBarrierTable} where cabd_id is not null; 
         """
         with conn.cursor() as cursor:
             cursor.execute(query)
@@ -127,6 +126,8 @@ def main():
                 passability_status,
                 type)
             VALUES (%s, ST_Transform(ST_GeomFromText('POINT(%s %s)',4617),{appconfig.dataSrid}), %s, %s, %s, UPPER(%s), 'dam');
+
+            UPDATE {dbTargetSchema}.{dbBarrierTable} SET id = cabd_id WHERE type = 'dam';
         """
         with conn.cursor() as cursor:
             for feature in output_data:

--- a/src/processing_scripts/load_assessment_data.py
+++ b/src/processing_scripts/load_assessment_data.py
@@ -82,8 +82,6 @@ def loadAssessmentData(connection):
     # print(pycmd)
     subprocess.run(pycmd)
 
-    # TO DO: create new copy of predicted_points table where owner is 
-    # converted to ownership_type
     query = f"""
         INSERT INTO {dbTargetSchema}.{dbTargetTable} (
             disp_num,
@@ -234,7 +232,7 @@ def loadToBarriers(connection):
         DELETE FROM {dbTargetSchema}.{dbBarrierTable} WHERE type = 'stream_crossing';
         
         INSERT INTO {dbTargetSchema}.{dbBarrierTable}(
-            modelled_id, assessment_id, snapped_point,
+            id, modelled_id, assessment_id, snapped_point,
             type, owner, passability_status, disp_num,
             stream_name, strahler_order, stream_id, 
             transport_feature_name, critical_habitat,
@@ -244,7 +242,7 @@ def loadToBarriers(connection):
             year_planned, year_complete, comments
         )
         SELECT 
-            modelled_id, assessment_id, geometry,
+            modelled_id, modelled_id, assessment_id, geometry,
             'stream_crossing', ownership_type, passability_status, disp_num,
             stream_name, strahler_order, stream_id, 
             transport_feature_name, critical_habitat,


### PR DESCRIPTION
**Habitat and connectivity status**
- Stream segments with a Strahler order = 1 will no longer be considered habitat
- Potentially accessible habitat statistic added
- Connectivity status calculation changed to all accessible habitat segments divided by (all accessible habitat segments + all potentially accessible habitat segments)
- Previous connectivity status calculation was all accessible segments divided by (all accessible segments + all potentially accessible segments)

**Modelled crossing updates**
- cabd_id used as unique id for dams
- modelled_id used as unique id for stream crossings
- modelled_id for stream crossings is now stable - `compute_modelled_crossings.py` will now create an archive table of previous modelled crossings and set the modelled_id for newly-generated stream crossings to match previous values, based on a distance threshold.